### PR TITLE
Add finished property to counters to check if they have been stopped

### DIFF
--- a/src/org/flintparticles/common/counters/Blast.as
+++ b/src/org/flintparticles/common/counters/Blast.as
@@ -128,5 +128,13 @@ package org.flintparticles.common.counters
 		{
 			return _done;
 		}
+		
+		/**
+		 * Indicates if the counter is currently emitting particles
+		 */
+		public function get running():Boolean
+		{
+			return false;
+		}
 	}
 }

--- a/src/org/flintparticles/common/counters/Counter.as
+++ b/src/org/flintparticles/common/counters/Counter.as
@@ -85,5 +85,10 @@ package org.flintparticles.common.counters
 		 * Indicates if the counter has emitted all its particles
 		 */
 		function get complete():Boolean;
+		
+		/**
+		 * Indicates if the counter is currently emitting particles
+		 */
+		function get running():Boolean;
 	}
 }

--- a/src/org/flintparticles/common/counters/KeyDownCounter.as
+++ b/src/org/flintparticles/common/counters/KeyDownCounter.as
@@ -175,5 +175,13 @@ package org.flintparticles.common.counters
 		{
 			return _counter.complete;
 		}
+		
+		/**
+		 * Indicates if the counter is currently emitting particles
+		 */
+		public function get running():Boolean
+		{
+			return _counter.running;
+		}
 	}
 }

--- a/src/org/flintparticles/common/counters/PerformanceAdjusted.as
+++ b/src/org/flintparticles/common/counters/PerformanceAdjusted.as
@@ -50,7 +50,7 @@ package org.flintparticles.common.counters
 		private var _rate:Number;
 		private var _times:Array;
 		private var _timeToRateCheck:Number;
-		private var _stop:Boolean;
+		private var _running:Boolean;
 		
 		/**
 		 * The constructor creates a PerformanceAdjusted counter for use by an 
@@ -70,7 +70,7 @@ package org.flintparticles.common.counters
 		 */
 		public function PerformanceAdjusted( rateMin:Number = 0, rateMax:Number = 0, targetFrameRate:Number = 24 )
 		{
-			_stop = false;
+			_running = false;
 			_rateMin = rateMin;
 			_rate = _rateMax = rateMax;
 			_target = targetFrameRate;
@@ -128,7 +128,7 @@ package org.flintparticles.common.counters
 		 */
 		public function stop():void
 		{
-			_stop = true;
+			_running = false;
 		}
 		
 		/**
@@ -136,7 +136,7 @@ package org.flintparticles.common.counters
 		 */
 		public function resume():void
 		{
-			_stop = false;
+			_running = true;
 		}
 		
 		/**
@@ -153,6 +153,7 @@ package org.flintparticles.common.counters
 		 */
 		public function startEmitter( emitter:Emitter ):uint
 		{
+			_running = true;
 			newTimeToNext();
 			return 0;
 		}
@@ -178,7 +179,7 @@ package org.flintparticles.common.counters
 		 */
 		public function updateEmitter( emitter:Emitter, time:Number ):uint
 		{
-			if( _stop )
+			if( !_running )
 			{
 				return 0;
 			}
@@ -224,6 +225,14 @@ package org.flintparticles.common.counters
 		public function get complete():Boolean
 		{
 			return false;
+		}
+		
+		/**
+		 * Indicates if the counter is currently emitting particles
+		 */
+		public function get running():Boolean
+		{
+			return _running;
 		}
 	}
 }

--- a/src/org/flintparticles/common/counters/Pulse.as
+++ b/src/org/flintparticles/common/counters/Pulse.as
@@ -41,7 +41,7 @@ package org.flintparticles.common.counters
 		private var _timeToNext:Number;
 		private var _period:Number;
 		private var _quantity:Number;
-		private var _stop:Boolean;
+		private var _running:Boolean;
 		
 		/**
 		 * The constructor creates a Pulse counter for use by an emitter. To
@@ -54,7 +54,7 @@ package org.flintparticles.common.counters
 		 */
 		public function Pulse( period:Number = 1, quantity:uint = 0 )
 		{
-			_stop = false;
+			_running = false;
 			_quantity = quantity;
 			_period = period;
 		}
@@ -64,7 +64,7 @@ package org.flintparticles.common.counters
 		 */
 		public function stop():void
 		{
-			_stop = true;
+			_running = false;
 		}
 		
 		/**
@@ -72,7 +72,7 @@ package org.flintparticles.common.counters
 		 */
 		public function resume():void
 		{
-			_stop = false;
+			_running = true;
 		}
 		
 		/**
@@ -113,6 +113,7 @@ package org.flintparticles.common.counters
 		 */
 		public function startEmitter( emitter:Emitter ):uint
 		{
+			_running = true;
 			_timeToNext = _period;
 			return _quantity;
 		}
@@ -132,7 +133,7 @@ package org.flintparticles.common.counters
 		 */
 		public function updateEmitter( emitter:Emitter, time:Number ):uint
 		{
-			if( _stop )
+			if( !_running )
 			{
 				return 0;
 			}
@@ -153,6 +154,14 @@ package org.flintparticles.common.counters
 		public function get complete():Boolean
 		{
 			return false;
+		}
+		
+		/**
+		 * Indicates if the counter is currently emitting particles
+		 */
+		public function get running():Boolean
+		{
+			return _running;
 		}
 	}
 }

--- a/src/org/flintparticles/common/counters/Random.as
+++ b/src/org/flintparticles/common/counters/Random.as
@@ -41,7 +41,7 @@ package org.flintparticles.common.counters
 		private var _timeToNext:Number;
 		private var _minRate:Number;
 		private var _maxRate:Number;
-		private var _stop:Boolean;
+		private var _running:Boolean;
 		
 		/**
 		 * The constructor creates a Random counter for use by an emitter. To
@@ -54,7 +54,7 @@ package org.flintparticles.common.counters
 		 */
 		public function Random( minRate:Number = 0, maxRate:Number = 0 )
 		{
-			_stop = false;
+			_running = false;
 			_minRate = minRate;
 			_maxRate = maxRate;
 		}
@@ -64,7 +64,7 @@ package org.flintparticles.common.counters
 		 */
 		public function stop():void
 		{
-			_stop = true;
+			_running = false;
 		}
 		
 		/**
@@ -72,7 +72,7 @@ package org.flintparticles.common.counters
 		 */
 		public function resume():void
 		{
-			_stop = false;
+			_running = true;
 		}
 		
 		/**
@@ -138,7 +138,7 @@ package org.flintparticles.common.counters
 		 */
 		public function updateEmitter( emitter:Emitter, time:Number ):uint
 		{
-			if( _stop )
+			if( !_running )
 			{
 				return 0;
 			}
@@ -159,6 +159,14 @@ package org.flintparticles.common.counters
 		public function get complete():Boolean
 		{
 			return false;
+		}
+		
+		/**
+		 * Indicates if the counter is currently emitting particles
+		 */
+		public function get running():Boolean
+		{
+			return _running;
 		}
 	}
 }

--- a/src/org/flintparticles/common/counters/SineCounter.as
+++ b/src/org/flintparticles/common/counters/SineCounter.as
@@ -42,7 +42,7 @@ package org.flintparticles.common.counters
 		private var _rateMin:Number;
 		private var _rateMax:Number;
 		private var _period:Number;
-		private var _stop:Boolean;
+		private var _running:Boolean;
 		private var _timePassed:Number;
 		private var _factor:Number;
 		private var _scale:Number;
@@ -61,7 +61,7 @@ package org.flintparticles.common.counters
 		 */
 		public function SineCounter( period:Number = 1, rateMax:Number = 0, rateMin:Number = 0 )
 		{
-			_stop = false;
+			_running = false;
 			_period = period;
 			_rateMin = rateMin;
 			_rateMax = rateMax;
@@ -74,7 +74,7 @@ package org.flintparticles.common.counters
 		 */
 		public function stop():void
 		{
-			_stop = true;
+			_running = false;
 		}
 		
 		/**
@@ -82,7 +82,7 @@ package org.flintparticles.common.counters
 		 */
 		public function resume():void
 		{
-			_stop = false;
+			_running = true;
 			_emitted = 0;
 		}
 		
@@ -141,6 +141,7 @@ package org.flintparticles.common.counters
 		 */
 		public function startEmitter( emitter:Emitter ):uint
 		{
+			_running = true;
 			_timePassed = 0;
 			_emitted = 0;
 			return 0;
@@ -161,7 +162,7 @@ package org.flintparticles.common.counters
 		 */
 		public function updateEmitter( emitter:Emitter, time:Number ):uint
 		{
-			if( _stop )
+			if( !_running )
 			{
 				return 0;
 			}
@@ -179,6 +180,14 @@ package org.flintparticles.common.counters
 		public function get complete():Boolean
 		{
 			return false;
+		}
+		
+		/**
+		 * Indicates if the counter is currently emitting particles
+		 */
+		public function get running():Boolean
+		{
+			return _running;
 		}
 	}
 }

--- a/src/org/flintparticles/common/counters/Steady.as
+++ b/src/org/flintparticles/common/counters/Steady.as
@@ -42,7 +42,7 @@ package org.flintparticles.common.counters
 		private var _timeToNext:Number;
 		private var _rate:Number;
 		private var _rateInv:Number;
-		private var _stop:Boolean;
+		private var _running:Boolean;
 		
 		/**
 		 * The constructor creates a Steady counter for use by an emitter. To
@@ -54,7 +54,7 @@ package org.flintparticles.common.counters
 		 */
 		public function Steady( rate:Number = 0 )
 		{
-			_stop = false;
+			_running = false;
 			this.rate = rate;
 		}
 		
@@ -63,7 +63,7 @@ package org.flintparticles.common.counters
 		 */
 		public function stop():void
 		{
-			_stop = true;
+			_running = false;
 		}
 		
 		/**
@@ -71,7 +71,7 @@ package org.flintparticles.common.counters
 		 */
 		public function resume():void
 		{
-			_stop = false;
+			_running = true;
 		}
 		
 		/**
@@ -119,6 +119,7 @@ package org.flintparticles.common.counters
 		 */
 		public function startEmitter( emitter:Emitter ):uint
 		{
+			_running = true;
 			_timeToNext = _rateInv;
 			return 0;
 		}
@@ -138,7 +139,7 @@ package org.flintparticles.common.counters
 		 */
 		public function updateEmitter( emitter:Emitter, time:Number ):uint
 		{
-			if( _stop )
+			if( !_running )
 			{
 				return 0;
 			}
@@ -159,6 +160,14 @@ package org.flintparticles.common.counters
 		public function get complete():Boolean
 		{
 			return false;
+		}
+		
+		/**
+		 * Indicates if the counter is currently emitting particles
+		 */
+		public function get running():Boolean
+		{
+			return _running;
 		}
 	}
 }

--- a/src/org/flintparticles/common/counters/TimePeriod.as
+++ b/src/org/flintparticles/common/counters/TimePeriod.as
@@ -50,7 +50,7 @@ package org.flintparticles.common.counters
 		private var _particlesPassed : uint;
 		private var _timePassed : Number;
 		private var _easing : Function;
-		private var _stop : Boolean = false;
+		private var _running : Boolean = false;
 
 		/**
 		 * The constructor creates a TimePeriod counter for use by an emitter. To
@@ -134,6 +134,7 @@ package org.flintparticles.common.counters
 		 */
 		public function startEmitter( emitter:Emitter ) : uint
 		{
+			_running = true;
 			_particlesPassed = 0;
 			_timePassed = 0;
 			return 0;
@@ -154,7 +155,7 @@ package org.flintparticles.common.counters
 		 */
 		public function updateEmitter( emitter:Emitter, time : Number ) : uint
 		{
-			if( _stop || _timePassed >= _duration )
+			if( !_running || _timePassed >= _duration )
 			{
 				return 0;
 			}
@@ -179,7 +180,7 @@ package org.flintparticles.common.counters
 		 */
 		public function stop():void
 		{
-			_stop = true;
+			_running = false;
 		}
 		
 		/**
@@ -187,7 +188,7 @@ package org.flintparticles.common.counters
 		 */
 		public function resume():void
 		{
-			_stop = false;
+			_running = true;
 		}
 
 		/**
@@ -196,6 +197,14 @@ package org.flintparticles.common.counters
 		public function get complete():Boolean
 		{
 			return _particlesPassed == _particles;
+		}
+		
+		/**
+		 * Indicates if the counter is currently emitting particles
+		 */
+		public function get running():Boolean
+		{
+			return (_running && _timePassed < _duration);
 		}
 	}
 }

--- a/src/org/flintparticles/common/counters/ZeroCounter.as
+++ b/src/org/flintparticles/common/counters/ZeroCounter.as
@@ -105,5 +105,13 @@ package org.flintparticles.common.counters
 		{
 			return true;
 		}
+		
+		/**
+		 * Indicates if the counter is currently emitting particles
+		 */
+		public function get running():Boolean
+		{
+			return false;
+		}
 	}
 }


### PR DESCRIPTION
I try to implement auto-destruction for my particle systems. I listen for the EMITTER_EMPTY event and then check which emitters are done and if the whole system can be removed. This works well for limited counters like Blast, where I can just check the complete property to find if the emitter can be removed.

In case of e.g. the Steady counter, when I want to stop the system at some point and have it auto-destruct when all particles are gone, there's no way to tell if the Steady counter has been stopped or if it just emits so few particles that the emitter triggers EMITTER_EMPTY in between.

Therefore I added a running property to the counters so that it can be checked if they have been stopped and the emitter removed accordingly.
